### PR TITLE
Enable Hackage-friendly stack.yaml settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,4 @@ packages:
 - .
 flags: {}
 extra-deps: []
-
+pvp-bounds: both


### PR DESCRIPTION
This will transparently add upper and lower bounds to all package dependencies not currently having them, based on the snapshot in use, when the package is uploaded via either stack upload or stack sdist.